### PR TITLE
Fix importing occlusions from .ymap files

### DIFF
--- a/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs
+++ b/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs
@@ -3309,6 +3309,7 @@ namespace CodeWalker.GameFiles
             Vertices = MetaTypes.ConvertDataArray<Vector3>(Data, 0, vertexCount);
             Indices = new byte[indexCount];
             Buffer.BlockCopy(Data, indicesOffset, Indices, 0, indexCount);
+            BuildTriangles();
         }
 
 


### PR DESCRIPTION
Occlude Models from imported .ymap files was not being recognized properly. The triangles count being shown on Project window was always being 0.